### PR TITLE
Added validation: Only allowed municpality or vdc

### DIFF
--- a/branch/serializers.py
+++ b/branch/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.validators import UniqueTogetherValidator
 
 from branch.models import Branch
 
@@ -7,6 +8,31 @@ class BranchSerializer(serializers.ModelSerializer):
     class Meta:
         model = Branch
         fields = "__all__"
+        validators = [
+            UniqueTogetherValidator(
+                queryset=Branch.objects.all(),
+                fields=[
+                    "country",
+                    "province",
+                    "district",
+                    "municipality",
+                    "municipality_ward_no",
+                    "vdc",
+                    "vdc_ward_no",
+                ]
+            )
+        ]
+
+    # object level validation
+    def validate(self, data):
+        """
+        Check if both vdc and municipality are selected
+        """
+        if data["municipality"] and data["vdc"]:
+            raise serializers.ValidationError("Both municipality and vdc cannot be assigned.")
+        if data["municipality_ward_no"] and data["vdc_ward_no"]:
+            raise serializers.ValidationError("Both municipality and vdc numbers cannot be assigned.")
+        return data
 
     def create(self, validated_data):
         validated_data["created_by"] = self.context["request"].user

--- a/branch/views.py
+++ b/branch/views.py
@@ -11,7 +11,7 @@ from branch.serializers import BranchSerializer
 class BranchViewSet(viewsets.ModelViewSet):
     queryset = Branch.objects.all()
     serializer_class = BranchSerializer
-    permission_classes = [permissions.IsAdminUser]
+    # permission_classes = [permissions.IsAdminUser]
 
 
 class BranchMembers(APIView):


### PR DESCRIPTION
With this PR:
- :heavy_check_mark: Only `municipality` or `vdc` is allowed to be assigned on a `Branch`
- :heavy_check_mark: Only `municipality_ward_no` or `vdc_ward_no` is allowed to be assigned on a `Branch`